### PR TITLE
Feature/fix rollup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 doc
+build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+##### 0.5.7 - 09 September 2016
+
+- Upgraded dependencies
+- Removed dependency `babel-preset-es2015-rollup`
+- Added rollup example config to resolve [babel issue #71](https://github.com/rollup/rollup-plugin-babel/issues/71)
+
 ##### 0.5.6 - 10 August 2016
 
 - Upgraded dependencies

--- a/examples/rollup/index.js
+++ b/examples/rollup/index.js
@@ -1,0 +1,6 @@
+// can rollup process this?
+const foo = {
+  bar: "baz"
+}
+
+export const {bar} = foo

--- a/examples/rollup/rollup.config.js
+++ b/examples/rollup/rollup.config.js
@@ -1,0 +1,13 @@
+import babel from 'rollup-plugin-babel'
+
+export default {
+  moduleName: 'ReopTools',
+  moduleId: 'repo-tools',
+  plugins: [
+    babel({
+      babelrc: false,
+      presets: [['es2015', { "modules": false }]], // note the nested arrays
+      exclude: 'node_modules/**'
+    })
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -31,29 +31,30 @@
   },
   "scripts": {
     "lint": "node . lint",
+    "rollup": "rollup examples/rollup/index.js -c examples/rollup/rollup.config.js -o examples/rollup/build/rollup-example.js -m examples/rollup/build/rollup-example.js.map -f umd",
     "test": "npm run lint && node . changelog && node . updates && node . authors",
     "release": "npm test"
   },
   "dependencies": {
-    "babel-core": "^6.13.2",
+    "babel-core": "^6.14.0",
     "babel-eslint": "^6.1.2",
     "babel-polyfill": "^6.13.0",
-    "babel-preset-es2015": "^6.13.2",
+    "babel-preset-es2015": "^6.14.0",
     "babel-preset-es2015-rollup": "^1.2.0",
-    "bluebird": "^3.4.1",
+    "bluebird": "^3.4.6",
     "chai": "^3.5.0",
     "commander": "^2.9.0",
     "ink-docstrap": "git+https://github.com/js-data/docstrap.git#cfbe45fa313e1628c493076d5e15d2b855dfbf2c",
-    "jsdoc": "^3.4.0",
-    "lodash": "^4.14.2",
+    "jsdoc": "^3.4.1",
+    "lodash": "^4.16.1",
     "mocha": "^3.0.2",
     "npm-check-updates": "^2.8.0",
-    "nyc": "^8.1.0",
-    "sinon": "^1.17.5",
+    "nyc": "^8.3.0",
+    "sinon": "^1.17.6",
     "source-map-support": "^0.4.2",
-    "standard": "^8.0.0",
-    "rollup": "^0.34.7",
+    "standard": "^8.1.0",
+    "rollup": "^0.36.0",
     "rollup-plugin-babel": "^2.6.1",
-    "watch": "^0.19.1"
+    "watch": "^0.19.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "js-data-repo-tools",
   "description": "Common utility scripts used by js-data repositories.",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "homepage": "https://github.com/js-data/js-data-repo-tools",
   "repository": {
     "type": "git",


### PR DESCRIPTION
##### 0.5.7 - 09 September 2016

- Upgraded dependencies
- Removed dependency `babel-preset-es2015-rollup`
- Added rollup example config to resolve [babel issue #71](https://github.com/rollup/rollup-plugin-babel/issues/71)
